### PR TITLE
Add support for node.js, Firefox, Chromium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ env:
   - TARGET=arm OS=linux M32=-m32
   - TARGET=m68k OS=linux M32=-m32
   - TARGET=pdp11 OS=unix M32=-m32 CHECK=check-16-bit
-  - TARGET=asmjs M32=
-  - TARGET=asmjs M32=-m32
+  - TARGET=asmjs M32= JS=js24
+  - TARGET=asmjs M32=-m32 JS=js24
+  - TARGET=asmjs M32=-m32 JS=nodejs
 matrix:
   exclude:
     - os: osx
@@ -26,9 +27,11 @@ matrix:
     - os: osx
       env: TARGET=pdp11 OS=unix M32=-m32 CHECK=check-16-bit
     - os: osx
-      env: TARGET=asmjs M32=
+      env: TARGET=asmjs M32= JS=js24
     - os: osx
-      env: TARGET=asmjs M32=-m32
+      env: TARGET=asmjs M32=-m32 JS=js24
+    - os: osx
+      env: TARGET=asmjs M32=-m32 JS=nodejs
 install: sh -e install-deps.sh install_${TRAVIS_OS_NAME:-linux}
 script: make ${CHECK:-check}  M32=$M32 TARGET=$TARGET OS=$OS
 notifications:

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -31,7 +31,12 @@ install_linux() {
     m68k-tos) download_tosemu;;
     pdp11-unix) download_apout;;
     avr-*) sudo apt-get install simulavr;;
-    asmjs-*) sudo apt-get install libmozjs-24-bin;;
+  esac
+  case "$TARGET-$JS" in
+    asmjs-js24) sudo apt-get install libmozjs-24-bin;;
+    asmjs-nodejs) 
+      wget -qO- https://deb.nodesource.com/setup_7.x | sudo -E bash -
+      sudo apt-get install nodejs;;
   esac
 }
 

--- a/targets/asmjs/forth.html
+++ b/targets/asmjs/forth.html
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US">
+  <head>
+    <title>lbForth</title>
+    <script>
+      window.onload = function () {
+          var node = document.getElementById("input");
+          document.getElementsByTagName("form")[0].addEventListener("submit", function (e) {
+              forth_output(node.value + "\n");
+              forth_input(node.value + "\n");
+              node.value = "";
+              e.preventDefault();
+          });
+
+          forth_output("");
+      };
+
+      var output = "";
+
+      function forth_output(str)
+      {
+          output += str;
+
+          var n = document.getElementById("output");
+
+          if (n) n.innerHTML = output;
+      }
+    </script>
+    <script type="application/javascript"
+            src="forth.js">
+    </script>
+  </head>
+  <body>
+    <pre style="white-space: pre-wrap !important">
+      <div id="output"></div>
+    </pre>
+    <form>
+      <input id="input"/>
+    </form>
+  </body>
+</html>

--- a/targets/asmjs/run.sh
+++ b/targets/asmjs/run.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-JS=js
-
-type js24 > /dev/null 2>&1 && JS="js24 -W"
+if test -z "$JS"; then
+    JS=js
+    type js24 > /dev/null 2>&1 && JS="js24 -W"
+fi
 
 $JS "$@"


### PR DESCRIPTION
Start addressing #36. `nodejs ./forth` should simply work; Firefox should work after copying `forth` to `forth.js` and `forth.html` to `forth.html` in the `lbForth/` directory; with the right security settings, a `file:///` url will work, but with a web server, it should always work. Chromium won't work with `file:///` urls (I believe there are command line options to fix this but I keep forgetting them), but should work with a web server just like Firefox does.

I can't really test Microsoft browsers, but I'm optimistic it shouldn't be too hard to get them working.

No VT100 emulation yet, and the first line of output ("lbForth") gets eaten right now.