### PR TITLE
Windows READ-FILE should return 0 0 on EOF

### DIFF
--- a/targets/asmjs/nucleus.fth
+++ b/targets/asmjs/nucleus.fth
@@ -294,7 +294,13 @@ function lbForth(stdlib, foreign, buffer)
     "use asm";
     var HEAPU8 = new stdlib.Uint8Array(buffer);
     var HEAPU32 = new stdlib.Uint32Array(buffer);
-    var imul = stdlib.Math.imul;
+    var imul = stdlib.Math.imul || function(a, b) {
+        var ah = (a >>> 16) & 0xffff;
+        var al = a & 0xffff;
+        var bh = (b >>> 16) & 0xffff;
+        var bl = b & 0xffff;
+        return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0)|0);
+    };
     var foreign_putchar = foreign.putchar;
     var foreign_open_file = foreign.open_file;
     var foreign_read_file = foreign.read_file;


### PR DESCRIPTION
When `ReadFile` returns error, check `GetLastError` for `ERROR_HANDLE_EOF`.

Then change `KEY` to call `ABORT` instead of `BYE` on errors.
