### PR TITLE
IE11 doesn't have imul

### DIFF
--- a/targets/asmjs/nucleus.fth
+++ b/targets/asmjs/nucleus.fth
@@ -294,7 +294,13 @@ function lbForth(stdlib, foreign, buffer)
     "use asm";
     var HEAPU8 = new stdlib.Uint8Array(buffer);
     var HEAPU32 = new stdlib.Uint32Array(buffer);
-    var imul = stdlib.Math.imul;
+    var imul = stdlib.Math.imul || function(a, b) {
+        var ah = (a >>> 16) & 0xffff;
+        var al = a & 0xffff;
+        var bh = (b >>> 16) & 0xffff;
+        var bl = b & 0xffff;
+        return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0)|0);
+    };
     var foreign_putchar = foreign.putchar;
     var foreign_open_file = foreign.open_file;
     var foreign_read_file = foreign.read_file;


### PR DESCRIPTION
The asm.js target doesn't work in IE11 due to a missing `Math.imul`.

Here's a replacement:  https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Math/imul