### PR TITLE
Add information about the cross compiler.

### DIFF
--- a/PITCHME.md
+++ b/PITCHME.md
@@ -67,10 +67,17 @@ http://github.com/larsbrinkhoff/lbForth
 
 ---
 
-## UPCOMING
+# CROSS COMPILER
 
 - Microcontrollers:  
-  AVR, PIC, MSP430, Thumb, Xtensa, STM8, 8051
+  AVR, PIC, MSP430, Thumb, STM8, 8051
+- Retro: 6502, PDP-8
+
+---
+
+# UPCOMING
+
+- Microcontrollers: Xtensa
 - Retro: PDP-10, C64, Z80 CP/M, 6809, 1802
 - Optimizing compiler
 - Run inside Emacs

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ new [metacompiler written in Forth](lib/meta.fth) generates an x86
 executable using using [assembly language code words](targets/x86/nucleus.fth).
 
 There are also ARM, RISC-V, Motorola 68000, PDP-11, and asm.js
-targets, and target assemblers for 6502, AVR, MSP430, and Emacs
-bytecodes.
+targets.  There is a [cross
+compiler](http://github.com/larsbrinkhoff/xForth) for 6502, 8051, AVR,
+Cortex-M, MSP430, PDP-8, PIC, and STM8.
 
 ( Continuous integration )
 


### PR DESCRIPTION
New targets:  6502, 8051, AVR, Cortex-M, MSP430, PDP-8, PIC, and STM8.
